### PR TITLE
arreglo el test de supervision al RESTServer

### DIFF
--- a/restserver_supervised/lib/restserver.ex
+++ b/restserver_supervised/lib/restserver.ex
@@ -3,8 +3,8 @@ defmodule RESTServer do
 
   ## Client API
 
-  def start_link do
-    GenServer.start_link(__MODULE__, :ok, [])
+  def start_link(name) do
+    GenServer.start_link(__MODULE__, :ok, [name: name])
   end
 
   def get(server, url) do

--- a/restserver_supervised/lib/restserver_supervised.ex
+++ b/restserver_supervised/lib/restserver_supervised.ex
@@ -1,41 +1,26 @@
-import RESTServer
-
 defmodule RESTServer.Supervisor do
   use Supervisor
 
-  @name RESTServer.Supervisor
+  ## Client API
 
   def start_link do
-    Supervisor.start_link(__MODULE__, :ok, name: @name)
+    Supervisor.start_link(__MODULE__, [])
   end
 
-  def start_restserver(state \\ []) do
-    {:ok, pid} = Supervisor.start_child(@name, state)
+  def start_restserver(sup, state \\ []) do
+    {:ok, pid} = Supervisor.start_child(sup, state)
     pid
   end
 
-  def get_supervisor do
-    case RESTServer.Supervisor.start_link do
-      {:ok, pid} -> pid
-      {:error, {:already_started, pid}} -> pid
-      {_, something} -> something
-    end
-  end
+  ## Server Callbacks
 
-  def get_worker(state \\ []) do
-    sup_pid = RESTServer.Supervisor.get_supervisor
-    {:ok, pid} = Supervisor.start_child(sup_pid, state)
-    pid
-  end
-
-  def init(:ok) do
-    import Supervisor.Spec
-
+  def init([]) do
     children = [
       worker(RESTServer, [], restart: :transient)
     ]
 
     supervise(children, strategy: :simple_one_for_one)
+    ##supervise(children, strategy: :simple_one_for_one, max_restarts: 3, max_seconds: 5)
   end
 
 end


### PR DESCRIPTION
Fixeo el problema de testear la supervision. El problema era que para este caso hay que agregar un sleep (o creo q un monitor, no lo comprobé todavía) porque sino el chequeo se hace antes que se pueda reiniciar.
Ahora esta funcionando bien, le cambie la API del supervisor así queda mas simple. También le agregue la posibilidad de poder registrar el RESTServer con un nombre así el testeo del supervisor era posible.
